### PR TITLE
Document license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"name": "vardot/blazy",
 	"description": "forked from dinbror/blazy to be used as drupal-library",
+	"license": "MIT",
 	"type": "drupal-library"
 }


### PR DESCRIPTION
bLazy is MIT licensed (https://github.com/dinbror/blazy/commit/4c57cab79f8fd0010eae32752feaed6199bab40f) but this is not detected by Packagist due to the missing license entry.

See warning currently visible at top of https://packagist.org/packages/vardot/blazy

If a license check of used components is made with `composer licenses` in eg a Drupal project, this package appears as one with "none" shown as a license.

`package.json` already contains the same license entry as this PR proposes.